### PR TITLE
fix(va04hl): added prototype for the start_rx_timer() in radio.h

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -3136,6 +3136,7 @@ static bool IsReJoin0Required( )
  */
 static void RxWindowSetup( TimerEvent_t* rxTimer, RxConfigParams_t* rxConfig )
 {
+    start_rx_timer();
     TimerStop( rxTimer );
 
     // Ensure the radio is Idle

--- a/src/radio/radio.h
+++ b/src/radio/radio.h
@@ -402,6 +402,7 @@ struct Radio_s
     void ( *SetRxDutyCycle ) ( uint32_t rxTime, uint32_t sleepTime );
 };
 
+void start_rx_timer(void);
 /*!
  * \brief Radio driver
  *


### PR DESCRIPTION
closes https://github.com/tadodotcom/RoomControl/issues/1878